### PR TITLE
feature(ep-03): add sleep tracking with accelerometer and manual input

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,6 +67,11 @@
             android:name=".ui.activity.HydrationActivity"
             android:exported="false" />
 
+        <!-- Sleep -->
+        <activity
+            android:name=".ui.activity.SleepActivity"
+            android:exported="false" />
+
         <service
             android:name=".service.StepCounterService"
             android:foregroundServiceType="health"

--- a/app/src/main/java/com/vitaltrack/app/data/local/dao/SleepDao.kt
+++ b/app/src/main/java/com/vitaltrack/app/data/local/dao/SleepDao.kt
@@ -1,0 +1,24 @@
+package com.vitaltrack.app.data.local.dao
+
+import androidx.room.*
+import com.vitaltrack.app.data.local.entity.SleepEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface SleepDao {
+
+    @Insert
+    suspend fun insert(sleep: SleepEntity): Long
+
+    @Update
+    suspend fun update(sleep: SleepEntity)
+
+    @Query("SELECT * FROM sleep WHERE endTime IS NOT NULL ORDER BY id DESC LIMIT 1")
+    fun getLatest(): Flow<SleepEntity?>
+
+    @Query("SELECT * FROM sleep ORDER BY date DESC LIMIT 7")
+    fun getLast7Days(): Flow<List<SleepEntity>>
+
+    @Query("SELECT * FROM sleep WHERE endTime IS NULL LIMIT 1")
+    suspend fun getOngoing(): SleepEntity?
+}

--- a/app/src/main/java/com/vitaltrack/app/data/local/database/VitalTrackDatabase.kt
+++ b/app/src/main/java/com/vitaltrack/app/data/local/database/VitalTrackDatabase.kt
@@ -3,10 +3,12 @@ package com.vitaltrack.app.data.local.database
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import com.vitaltrack.app.data.local.dao.GpsTrackingDao
+import com.vitaltrack.app.data.local.dao.SleepDao
 import com.vitaltrack.app.data.local.dao.StepCounterDao
 import com.vitaltrack.app.data.local.dao.UserDao
 import com.vitaltrack.app.data.local.dao.WaterIntakeDao
 import com.vitaltrack.app.data.local.entity.GpsTrackingEntity
+import com.vitaltrack.app.data.local.entity.SleepEntity
 import com.vitaltrack.app.data.local.entity.StepCounterEntity
 import com.vitaltrack.app.data.local.entity.UserEntity
 import com.vitaltrack.app.data.local.entity.WaterIntakeEntity
@@ -16,9 +18,10 @@ import com.vitaltrack.app.data.local.entity.WaterIntakeEntity
         UserEntity::class,
         StepCounterEntity::class,
         GpsTrackingEntity::class,
-        WaterIntakeEntity::class
+        WaterIntakeEntity::class,
+        SleepEntity::class
                ],
-    version = 4,
+    version = 5,
     exportSchema = false
 )
 
@@ -27,4 +30,5 @@ abstract class VitalTrackDatabase : RoomDatabase() {
     abstract fun stepCounterDao(): StepCounterDao
     abstract fun gpsTrackingDao(): GpsTrackingDao
     abstract fun waterIntakeDao(): WaterIntakeDao
+    abstract fun sleepDao(): SleepDao
 }

--- a/app/src/main/java/com/vitaltrack/app/data/local/entity/SleepEntity.kt
+++ b/app/src/main/java/com/vitaltrack/app/data/local/entity/SleepEntity.kt
@@ -1,0 +1,15 @@
+package com.vitaltrack.app.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "sleep")
+data class SleepEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val date: String,
+    val startTime: String,
+    val endTime: String?,
+    val durationMinutes: Int?,
+    val agitationCount: Int = 0
+)

--- a/app/src/main/java/com/vitaltrack/app/data/repository/SleepRepository.kt
+++ b/app/src/main/java/com/vitaltrack/app/data/repository/SleepRepository.kt
@@ -1,0 +1,78 @@
+package com.vitaltrack.app.data.repository
+
+import com.vitaltrack.app.data.local.dao.SleepDao
+import com.vitaltrack.app.data.local.entity.SleepEntity
+import kotlinx.coroutines.flow.Flow
+import java.text.SimpleDateFormat
+import java.util.*
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SleepRepository @Inject constructor(
+    private val sleepDao: SleepDao
+) {
+
+    private fun today(): String =
+        SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date())
+
+    private fun now(): String =
+        SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date())
+
+    fun getLatest(): Flow<SleepEntity?> = sleepDao.getLatest()
+
+    fun getLast7Days(): Flow<List<SleepEntity>> = sleepDao.getLast7Days()
+
+    suspend fun getOngoing(): SleepEntity? = sleepDao.getOngoing()
+
+    suspend fun startSleep(): Long {
+        val sleep = SleepEntity(
+            date = today(),
+            startTime = now(),
+            endTime = null,
+            durationMinutes = null
+        )
+        return sleepDao.insert(sleep)
+    }
+
+    suspend fun startSleepManual(startTime: String): Long {
+        val sleep = SleepEntity(
+            date = today(),
+            startTime = startTime,
+            endTime = null,
+            durationMinutes = null
+        )
+        return sleepDao.insert(sleep)
+    }
+
+    suspend fun endSleep(sleep: SleepEntity, endTime: String? = null): SleepEntity {
+        val end = endTime ?: now()
+        val duration = calculateDuration(sleep.startTime, end)
+        val updated = sleep.copy(endTime = end, durationMinutes = duration)
+        sleepDao.update(updated)
+        return updated
+    }
+
+    suspend fun incrementAgitation(sleep: SleepEntity) {
+        sleepDao.update(sleep.copy(agitationCount = sleep.agitationCount + 1))
+    }
+
+    suspend fun saveComplete(sleep: SleepEntity) {
+        sleepDao.insert(sleep)
+    }
+
+    private fun calculateDuration(start: String, end: String): Int {
+        return try {
+            val fmt = SimpleDateFormat("HH:mm", Locale.getDefault())
+            val startDate = fmt.parse(start) ?: return 0
+            val endDate = fmt.parse(end) ?: return 0
+            var diff = ((endDate.time - startDate.time) / 60000).toInt()
+            if (diff < 0) diff += 24 * 60 // passou da meia-noite
+            diff
+        } catch (e: Exception) {
+            0
+        }
+    }
+
+
+}

--- a/app/src/main/java/com/vitaltrack/app/di/DatabaseModule.kt
+++ b/app/src/main/java/com/vitaltrack/app/di/DatabaseModule.kt
@@ -3,6 +3,7 @@ package com.vitaltrack.app.di
 import android.content.Context
 import androidx.room.Room
 import com.vitaltrack.app.data.local.dao.GpsTrackingDao
+import com.vitaltrack.app.data.local.dao.SleepDao
 import com.vitaltrack.app.data.local.dao.StepCounterDao
 import com.vitaltrack.app.data.local.database.VitalTrackDatabase
 import com.vitaltrack.app.data.local.dao.UserDao
@@ -48,5 +49,10 @@ object DatabaseModule {
     @Provides
     fun provideWaterIntakeDao(database: VitalTrackDatabase): WaterIntakeDao {
         return database.waterIntakeDao()
+    }
+
+    @Provides
+    fun provideSleepDao(database: VitalTrackDatabase): SleepDao {
+        return database.sleepDao()
     }
 }

--- a/app/src/main/java/com/vitaltrack/app/ui/activity/DashboardActivity.kt
+++ b/app/src/main/java/com/vitaltrack/app/ui/activity/DashboardActivity.kt
@@ -44,6 +44,10 @@ class DashboardActivity : AppCompatActivity() {
         binding.cardHydration.setOnClickListener {
             startActivity(Intent(this, HydrationActivity::class.java))
         }
+
+        binding.cardSleep.setOnClickListener {
+            startActivity(Intent(this, SleepActivity::class.java))
+        }
     }
 
 

--- a/app/src/main/java/com/vitaltrack/app/ui/activity/SleepActivity.kt
+++ b/app/src/main/java/com/vitaltrack/app/ui/activity/SleepActivity.kt
@@ -1,0 +1,23 @@
+package com.vitaltrack.app.ui.activity
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.vitaltrack.app.databinding.ActivitySleepBinding
+import com.vitaltrack.app.ui.sleep.SleepFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class SleepActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivitySleepBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivitySleepBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        supportFragmentManager.beginTransaction()
+            .replace(binding.fragmentContainer.id, SleepFragment())
+            .commit()
+    }
+}

--- a/app/src/main/java/com/vitaltrack/app/ui/sleep/SleepFragment.kt
+++ b/app/src/main/java/com/vitaltrack/app/ui/sleep/SleepFragment.kt
@@ -1,0 +1,133 @@
+package com.vitaltrack.app.ui.sleep
+
+import android.app.AlertDialog
+import android.content.Context
+import android.hardware.SensorManager
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.EditText
+import androidx.appcompat.widget.LinearLayoutCompat
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import com.vitaltrack.app.databinding.FragmentSleepBinding
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class SleepFragment : Fragment() {
+
+    private var _binding: FragmentSleepBinding? = null
+    private val binding get() = _binding!!
+    private val viewModel: SleepViewModel by viewModels()
+    private lateinit var sensorManager: SensorManager
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentSleepBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        sensorManager = requireContext().getSystemService(Context.SENSOR_SERVICE) as SensorManager
+
+        setupButtons()
+        observeViewModel()
+    }
+
+    private fun setupButtons() {
+        binding.btnSleep.setOnClickListener {
+            viewModel.startSleep()
+            viewModel.registerSensor(sensorManager)
+        }
+
+        binding.btnWakeUp.setOnClickListener {
+            viewModel.endSleep()
+            viewModel.unregisterSensor(sensorManager)
+        }
+
+        binding.btnManual.setOnClickListener {
+            showManualDialog()
+        }
+    }
+
+    private fun showManualDialog() {
+        val layout = android.widget.LinearLayout(requireContext())
+        layout.orientation = android.widget.LinearLayout.VERTICAL
+        layout.setPadding(48, 24, 48, 0)
+
+        val etStart = EditText(requireContext()).apply { hint = "Início (ex: 22:30)" }
+        val etEnd = EditText(requireContext()).apply { hint = "Fim (ex: 06:30)" }
+
+        layout.addView(etStart)
+        layout.addView(etEnd)
+
+        AlertDialog.Builder(requireContext())
+            .setTitle("Inserir horários manualmente")
+            .setView(layout)
+            .setPositiveButton("Salvar") { _, _ ->
+                val start = etStart.text.toString().trim()
+                val end = etEnd.text.toString().trim()
+                if (start.isNotEmpty() && end.isNotEmpty()) {
+                    viewModel.saveSleepManual(start, end)
+                }
+            }
+            .setNegativeButton("Cancelar", null)
+            .show()
+    }
+
+    private fun observeViewModel() {
+        lifecycleScope.launch {
+            launch {
+                viewModel.uiState.collect { state ->
+                    when (state) {
+                        is SleepUiState.Idle -> {
+                            binding.btnSleep.visibility = View.VISIBLE
+                            binding.btnWakeUp.visibility = View.GONE
+                            binding.tvStatus.text = "Pronto para dormir?"
+                            binding.tvDuration.visibility = View.GONE
+                        }
+                        is SleepUiState.Sleeping -> {
+                            binding.btnSleep.visibility = View.GONE
+                            binding.btnWakeUp.visibility = View.VISIBLE
+                            binding.tvStatus.text = "Dormindo desde ${state.startTime}"
+                            binding.tvDuration.visibility = View.GONE
+                        }
+                        is SleepUiState.Done -> {
+                            binding.btnSleep.visibility = View.VISIBLE
+                            binding.btnWakeUp.visibility = View.GONE
+                            val hours = state.durationMinutes / 60
+                            val mins = state.durationMinutes % 60
+                            binding.tvStatus.text = "${state.startTime} → ${state.endTime}"
+                            binding.tvDuration.visibility = View.VISIBLE
+                            binding.tvDuration.text = "Duração: ${hours}h ${mins}min"
+                        }
+                    }
+                }
+            }
+            launch {
+                viewModel.latest.collect { sleep ->
+                    if (sleep?.endTime != null) {
+                        val hours = (sleep.durationMinutes ?: 0) / 60
+                        val mins = (sleep.durationMinutes ?: 0) % 60
+                        binding.tvLastSleep.text =
+                            "Última noite: ${sleep.startTime} → ${sleep.endTime} (${hours}h ${mins}min)"
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        viewModel.unregisterSensor(sensorManager)
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/vitaltrack/app/ui/sleep/SleepViewModel.kt
+++ b/app/src/main/java/com/vitaltrack/app/ui/sleep/SleepViewModel.kt
@@ -1,0 +1,158 @@
+package com.vitaltrack.app.ui.sleep
+
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.vitaltrack.app.data.local.entity.SleepEntity
+import com.vitaltrack.app.data.repository.SleepRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SleepViewModel @Inject constructor(
+    private val sleepRepository: SleepRepository
+) : ViewModel(), SensorEventListener {
+
+    private val _uiState = MutableStateFlow<SleepUiState>(SleepUiState.Idle)
+    val uiState: StateFlow<SleepUiState> = _uiState.asStateFlow()
+
+    private val _latest = MutableStateFlow<SleepEntity?>(null)
+    val latest: StateFlow<SleepEntity?> = _latest.asStateFlow()
+
+    private val _history = MutableStateFlow<List<SleepEntity>>(emptyList())
+    val history: StateFlow<List<SleepEntity>> = _history.asStateFlow()
+
+    private var ongoingSleep: SleepEntity? = null
+    private var agitationThreshold = 2f
+
+    init {
+        loadData()
+        checkOngoing()
+    }
+
+    private fun loadData() {
+        viewModelScope.launch {
+            launch {
+                sleepRepository.getLatest().collect { _latest.value = it }
+            }
+            launch {
+                sleepRepository.getLast7Days().collect { _history.value = it }
+            }
+        }
+    }
+
+    private fun checkOngoing() {
+        viewModelScope.launch {
+            val ongoing = sleepRepository.getOngoing()
+            if (ongoing != null) {
+                ongoingSleep = ongoing
+                _uiState.value = SleepUiState.Sleeping(ongoing.startTime)
+            }
+        }
+    }
+
+    fun startSleep() {
+        viewModelScope.launch {
+            val id = sleepRepository.startSleep()
+            ongoingSleep = sleepRepository.getOngoing()
+            _uiState.value = SleepUiState.Sleeping(ongoingSleep?.startTime ?: "")
+        }
+    }
+
+
+    fun endSleep() {
+        viewModelScope.launch {
+            val ongoing = ongoingSleep ?: return@launch
+            val result = sleepRepository.endSleep(ongoing)
+            ongoingSleep = null
+            _uiState.value = SleepUiState.Done(
+                startTime = result.startTime,
+                endTime = result.endTime ?: "",
+                durationMinutes = result.durationMinutes ?: 0
+            )
+        }
+    }
+
+
+    fun saveSleepManual(startTime: String, endTime: String) {
+        viewModelScope.launch {
+            // insere o registro completo de uma vez
+            val sleep = SleepEntity(
+                date = today(),
+                startTime = startTime,
+                endTime = endTime,
+                durationMinutes = calculateDuration(startTime, endTime)
+            )
+            sleepRepository.saveComplete(sleep)
+            _uiState.value = SleepUiState.Done(
+                startTime = startTime,
+                endTime = endTime,
+                durationMinutes = sleep.durationMinutes ?: 0
+            )
+        }
+    }
+
+    private fun today(): String =
+        java.text.SimpleDateFormat("yyyy-MM-dd", java.util.Locale.getDefault())
+            .format(java.util.Date())
+
+    private fun calculateDuration(start: String, end: String): Int {
+        return try {
+            val fmt = java.text.SimpleDateFormat("HH:mm", java.util.Locale.getDefault())
+            val startDate = fmt.parse(start) ?: return 0
+            val endDate = fmt.parse(end) ?: return 0
+            var diff = ((endDate.time - startDate.time) / 60000).toInt()
+            if (diff < 0) diff += 24 * 60
+            diff
+        } catch (e: Exception) { 0 }
+    }
+
+    fun registerSensor(sensorManager: SensorManager) {
+        val sensor = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+        sensor?.let {
+            sensorManager.registerListener(this, it, SensorManager.SENSOR_DELAY_NORMAL)
+        }
+    }
+
+    fun unregisterSensor(sensorManager: SensorManager) {
+        sensorManager.unregisterListener(this)
+    }
+
+    override fun onSensorChanged(event: SensorEvent?) {
+        if (event?.sensor?.type == Sensor.TYPE_ACCELEROMETER) {
+            val x = event.values[0]
+            val y = event.values[1]
+            val z = event.values[2]
+            val magnitude = Math.sqrt((x * x + y * y + z * z).toDouble()).toFloat()
+
+            // detecta agitação acima do threshold
+            if (magnitude > 12f && ongoingSleep != null) {
+                viewModelScope.launch {
+                    ongoingSleep?.let {
+                        sleepRepository.incrementAgitation(it)
+                        ongoingSleep = sleepRepository.getOngoing()
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {}
+}
+
+sealed class SleepUiState {
+    object Idle : SleepUiState()
+    data class Sleeping(val startTime: String) : SleepUiState()
+    data class Done(
+        val startTime: String,
+        val endTime: String,
+        val durationMinutes: Int
+    ) : SleepUiState()
+}

--- a/app/src/main/res/layout/activity_dashboard.xml
+++ b/app/src/main/res/layout/activity_dashboard.xml
@@ -127,6 +127,7 @@
 
             <!-- Sono -->
             <androidx.cardview.widget.CardView
+                android:id="@+id/cardSleep"
                 android:layout_width="0dp"
                 android:layout_height="100dp"
                 android:layout_columnWeight="1"

--- a/app/src/main/res/layout/activity_sleep.xml
+++ b/app/src/main/res/layout/activity_sleep.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <FrameLayout
+        android:id="@+id/fragmentContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_sleep.xml
+++ b/app/src/main/res/layout/fragment_sleep.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/background">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:gravity="center_horizontal"
+        android:padding="24dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Sono"
+            android:textSize="24sp"
+            android:textStyle="bold"
+            android:textColor="@color/text_primary" />
+
+        <TextView
+            android:id="@+id/tvStatus"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:text="Pronto para dormir?"
+            android:textSize="18sp"
+            android:textColor="@color/text_secondary"
+            android:gravity="center" />
+
+        <TextView
+            android:id="@+id/tvDuration"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textSize="16sp"
+            android:textColor="@color/sleep"
+            android:visibility="gone" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnSleep"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:layout_marginTop="32dp"
+            android:text="Dormir agora" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnWakeUp"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:layout_marginTop="16dp"
+            android:text="Acordei"
+            android:visibility="gone" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnManual"
+            style="@style/Widget.Material3.Button.OutlinedButton"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:layout_marginTop="8dp"
+            android:text="Inserir manualmente" />
+
+        <TextView
+            android:id="@+id/tvLastSleep"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:textSize="14sp"
+            android:textColor="@color/text_secondary"
+            android:gravity="center" />
+
+    </LinearLayout>
+
+</ScrollView>


### PR DESCRIPTION
## O que foi feito
Implementação da issue #7 — Registrar Horário de Sono

## Mudanças
* `SleepEntity` criada para persistir registros de sono no Room DB
* `SleepDao` com queries de inserção, atualização e busca
* `VitalTrackDatabase` atualizado para versão 5
* `DatabaseModule` atualizado com `SleepDao`
* `SleepRepository` com lógica de início, fim e cálculo de duração
* `SleepViewModel` com estados: Idle, Sleeping, Done e sensor de agitação
* `SleepFragment` com botões "Dormir agora", "Acordei" e inserção manual
* `fragment_sleep.xml` com layout completo
* `SleepActivity` criada para hospedar o fragment
* `DashboardActivity` atualizado com clique no card de Sono
* Query `getLatest` corrigida para ordenar por `id DESC`

## Critérios de aceite atendidos
* [x] Botão "Dormir agora" registra horário de início do sono
* [x] Botão "Acordei" registra horário de fim do sono
* [x] Duração total calculada automaticamente
* [x] Inserção manual de horários disponível como alternativa
* [x] Acelerômetro ativado durante o período de sono
* [x] Registro salvo no Room DB com data, início, fim e duração


Closes #7