### PR TITLE
feature(ep-03): add sleep score with classification, tips and history

### DIFF
--- a/app/src/main/java/com/vitaltrack/app/data/local/dao/SleepDao.kt
+++ b/app/src/main/java/com/vitaltrack/app/data/local/dao/SleepDao.kt
@@ -16,9 +16,15 @@ interface SleepDao {
     @Query("SELECT * FROM sleep WHERE endTime IS NOT NULL ORDER BY id DESC LIMIT 1")
     fun getLatest(): Flow<SleepEntity?>
 
-    @Query("SELECT * FROM sleep ORDER BY date DESC LIMIT 7")
+    @Query("SELECT * FROM sleep WHERE endTime IS NOT NULL ORDER BY id DESC LIMIT 7")
     fun getLast7Days(): Flow<List<SleepEntity>>
 
     @Query("SELECT * FROM sleep WHERE endTime IS NULL LIMIT 1")
     suspend fun getOngoing(): SleepEntity?
+
+    @Query("SELECT * FROM sleep WHERE endTime IS NOT NULL ORDER BY id DESC LIMIT 2")
+    suspend fun getLastTwo(): List<SleepEntity>
+
+    @Delete
+    suspend fun delete(sleep: SleepEntity)
 }

--- a/app/src/main/java/com/vitaltrack/app/data/repository/SleepRepository.kt
+++ b/app/src/main/java/com/vitaltrack/app/data/repository/SleepRepository.kt
@@ -61,6 +61,8 @@ class SleepRepository @Inject constructor(
         sleepDao.insert(sleep)
     }
 
+    suspend fun getLastTwo(): List<SleepEntity> = sleepDao.getLastTwo()
+
     private fun calculateDuration(start: String, end: String): Int {
         return try {
             val fmt = SimpleDateFormat("HH:mm", Locale.getDefault())
@@ -72,6 +74,70 @@ class SleepRepository @Inject constructor(
         } catch (e: Exception) {
             0
         }
+    }
+
+    fun calculateScore(sleep: SleepEntity, previousSleep: SleepEntity?): Int {
+        val durationMinutes = sleep.durationMinutes ?: 0
+
+        // mínimo de 60 minutos para ter pontuação
+        if (durationMinutes < 60) return 0
+
+        var score = 0
+        val hours = durationMinutes / 60f
+
+        score += when {
+            hours >= 7f && hours <= 9f -> 60
+            hours >= 6f && hours < 7f  -> 45
+            hours >= 9f && hours < 10f -> 45
+            hours >= 5f && hours < 6f  -> 30
+            hours >= 1f && hours < 5f  -> 15
+            else                       -> 0
+        }
+
+        if (previousSleep != null) {
+            val fmt = java.text.SimpleDateFormat("HH:mm", java.util.Locale.getDefault())
+            try {
+                val prevStart = fmt.parse(previousSleep.startTime)
+                val currStart = fmt.parse(sleep.startTime)
+                if (prevStart != null && currStart != null) {
+                    val diff = Math.abs(currStart.time - prevStart.time) / 60000
+                    score += when {
+                        diff <= 30  -> 25
+                        diff <= 60  -> 15
+                        diff <= 120 -> 10
+                        else        -> 0
+                    }
+                }
+            } catch (e: Exception) { score += 10 }
+        } else {
+            score += 10
+        }
+
+        score += when {
+            sleep.agitationCount == 0 -> 15
+            sleep.agitationCount <= 3 -> 10
+            sleep.agitationCount <= 8 -> 5
+            else                      -> 0
+        }
+
+        return score.coerceIn(0, 100)
+    }
+    fun getClassification(score: Int): String = when {
+        score >= 80 -> "Excelente"
+        score >= 60 -> "Bom"
+        score >= 40 -> "Regular"
+        else        -> "Ruim"
+    }
+
+    fun getTip(score: Int): String = when {
+        score >= 80 -> "Parabéns! Você está dormindo muito bem. Continue mantendo essa rotina."
+        score >= 60 -> "Seu sono está bom. Tente manter horários mais consistentes para melhorar."
+        score >= 40 -> "Seu sono está regular. Evite telas antes de dormir e mantenha um horário fixo."
+        else        -> "Seu sono precisa de atenção. Tente dormir e acordar sempre no mesmo horário."
+    }
+
+    suspend fun delete(sleep: SleepEntity) {
+        sleepDao.delete(sleep)
     }
 
 

--- a/app/src/main/java/com/vitaltrack/app/ui/sleep/SleepFragment.kt
+++ b/app/src/main/java/com/vitaltrack/app/ui/sleep/SleepFragment.kt
@@ -8,10 +8,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
-import androidx.appcompat.widget.LinearLayoutCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.vitaltrack.app.databinding.FragmentSleepBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -23,6 +23,7 @@ class SleepFragment : Fragment() {
     private val binding get() = _binding!!
     private val viewModel: SleepViewModel by viewModels()
     private lateinit var sensorManager: SensorManager
+    private val historyAdapter = SleepHistoryAdapter { viewModel.delete(it) }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -37,6 +38,11 @@ class SleepFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         sensorManager = requireContext().getSystemService(Context.SENSOR_SERVICE) as SensorManager
+
+        binding.rvHistory.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = historyAdapter
+        }
 
         setupButtons()
         observeViewModel()
@@ -113,6 +119,30 @@ class SleepFragment : Fragment() {
                 }
             }
             launch {
+                viewModel.score.collect { score ->
+                    if (score > 0) {
+                        binding.tvScore.visibility = View.VISIBLE
+                        binding.tvScore.text = "$score"
+                    }
+                }
+            }
+            launch {
+                viewModel.classification.collect { classification ->
+                    if (classification.isNotEmpty()) {
+                        binding.tvClassification.visibility = View.VISIBLE
+                        binding.tvClassification.text = classification
+                    }
+                }
+            }
+            launch {
+                viewModel.tip.collect { tip ->
+                    if (tip.isNotEmpty()) {
+                        binding.tvTip.visibility = View.VISIBLE
+                        binding.tvTip.text = tip
+                    }
+                }
+            }
+            launch {
                 viewModel.latest.collect { sleep ->
                     if (sleep?.endTime != null) {
                         val hours = (sleep.durationMinutes ?: 0) / 60
@@ -120,6 +150,11 @@ class SleepFragment : Fragment() {
                         binding.tvLastSleep.text =
                             "Última noite: ${sleep.startTime} → ${sleep.endTime} (${hours}h ${mins}min)"
                     }
+                }
+            }
+            launch {
+                viewModel.history.collect { history ->
+                    historyAdapter.submitList(history)
                 }
             }
         }

--- a/app/src/main/java/com/vitaltrack/app/ui/sleep/SleepHistoryAdapter.kt
+++ b/app/src/main/java/com/vitaltrack/app/ui/sleep/SleepHistoryAdapter.kt
@@ -1,0 +1,44 @@
+package com.vitaltrack.app.ui.sleep
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.vitaltrack.app.databinding.ItemSleepHistoryBinding
+
+class SleepHistoryAdapter(
+    private val onDelete: (SleepWithScore) -> Unit
+) : ListAdapter<SleepWithScore, SleepHistoryAdapter.ViewHolder>(DiffCallback()) {
+
+    inner class ViewHolder(private val binding: ItemSleepHistoryBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: SleepWithScore) {
+            val hours = (item.sleep.durationMinutes ?: 0) / 60
+            val mins = (item.sleep.durationMinutes ?: 0) % 60
+            binding.tvDate.text = item.sleep.date
+            binding.tvDuration.text = "${hours}h ${mins}min"
+            binding.tvScore.text = "${item.score}"
+            binding.tvClassification.text = item.classification
+            binding.btnDelete.setOnClickListener { onDelete(item) }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = ItemSleepHistoryBinding.inflate(
+            LayoutInflater.from(parent.context), parent, false
+        )
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class DiffCallback : DiffUtil.ItemCallback<SleepWithScore>() {
+        override fun areItemsTheSame(a: SleepWithScore, b: SleepWithScore) =
+            a.sleep.id == b.sleep.id
+        override fun areContentsTheSame(a: SleepWithScore, b: SleepWithScore) = a == b
+    }
+}

--- a/app/src/main/java/com/vitaltrack/app/ui/sleep/SleepViewModel.kt
+++ b/app/src/main/java/com/vitaltrack/app/ui/sleep/SleepViewModel.kt
@@ -26,8 +26,17 @@ class SleepViewModel @Inject constructor(
     private val _latest = MutableStateFlow<SleepEntity?>(null)
     val latest: StateFlow<SleepEntity?> = _latest.asStateFlow()
 
-    private val _history = MutableStateFlow<List<SleepEntity>>(emptyList())
-    val history: StateFlow<List<SleepEntity>> = _history.asStateFlow()
+    private val _history = MutableStateFlow<List<SleepWithScore>>(emptyList())
+    val history: StateFlow<List<SleepWithScore>> = _history.asStateFlow()
+
+    private val _score = MutableStateFlow(0)
+    val score: StateFlow<Int> = _score.asStateFlow()
+
+    private val _tip = MutableStateFlow("")
+    val tip: StateFlow<String> = _tip.asStateFlow()
+
+    private val _classification = MutableStateFlow("")
+    val classification: StateFlow<String> = _classification.asStateFlow()
 
     private var ongoingSleep: SleepEntity? = null
     private var agitationThreshold = 2f
@@ -37,13 +46,32 @@ class SleepViewModel @Inject constructor(
         checkOngoing()
     }
 
+
+
     private fun loadData() {
         viewModelScope.launch {
             launch {
-                sleepRepository.getLatest().collect { _latest.value = it }
+                sleepRepository.getLatest().collect { sleep ->
+                    _latest.value = sleep
+                    if (sleep?.endTime != null) {
+                        val lastTwo = sleepRepository.getLastTwo()
+                        val previous = if (lastTwo.size >= 2) lastTwo[1] else null
+                        val s = sleepRepository.calculateScore(sleep, previous)
+                        _score.value = s
+                        _classification.value = sleepRepository.getClassification(s)
+                        _tip.value = sleepRepository.getTip(s)
+                    }
+                }
             }
             launch {
-                sleepRepository.getLast7Days().collect { _history.value = it }
+                sleepRepository.getLast7Days().collect { list ->
+                    _history.value = list
+                        .filter { it.endTime != null }
+                        .map { sleep ->
+                            val s = sleepRepository.calculateScore(sleep, null)
+                            SleepWithScore(sleep, s, sleepRepository.getClassification(s))
+                        }
+                }
             }
         }
     }
@@ -83,7 +111,6 @@ class SleepViewModel @Inject constructor(
 
     fun saveSleepManual(startTime: String, endTime: String) {
         viewModelScope.launch {
-            // insere o registro completo de uma vez
             val sleep = SleepEntity(
                 date = today(),
                 startTime = startTime,
@@ -96,6 +123,8 @@ class SleepViewModel @Inject constructor(
                 endTime = endTime,
                 durationMinutes = sleep.durationMinutes ?: 0
             )
+            // força recarregar o histórico
+            loadData()
         }
     }
 
@@ -123,6 +152,12 @@ class SleepViewModel @Inject constructor(
 
     fun unregisterSensor(sensorManager: SensorManager) {
         sensorManager.unregisterListener(this)
+    }
+
+    fun delete(item: SleepWithScore) {
+        viewModelScope.launch {
+            sleepRepository.delete(item.sleep)
+        }
     }
 
     override fun onSensorChanged(event: SensorEvent?) {

--- a/app/src/main/java/com/vitaltrack/app/ui/sleep/SleepWithScore.kt
+++ b/app/src/main/java/com/vitaltrack/app/ui/sleep/SleepWithScore.kt
@@ -1,0 +1,9 @@
+package com.vitaltrack.app.ui.sleep
+
+import com.vitaltrack.app.data.local.entity.SleepEntity
+
+data class SleepWithScore(
+    val sleep: SleepEntity,
+    val score: Int,
+    val classification: String
+)

--- a/app/src/main/res/layout/fragment_sleep.xml
+++ b/app/src/main/res/layout/fragment_sleep.xml
@@ -20,11 +20,41 @@
             android:textStyle="bold"
             android:textColor="@color/text_primary" />
 
+        <!-- Score da última noite -->
+        <TextView
+            android:id="@+id/tvScore"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:textSize="64sp"
+            android:textStyle="bold"
+            android:textColor="@color/sleep"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/tvClassification"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="18sp"
+            android:textColor="@color/sleep"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/tvTip"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="16dp"
+            android:textSize="14sp"
+            android:textColor="@color/text_secondary"
+            android:gravity="center"
+            android:visibility="gone" />
+
         <TextView
             android:id="@+id/tvStatus"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="32dp"
+            android:layout_marginTop="16dp"
             android:text="Pronto para dormir?"
             android:textSize="18sp"
             android:textColor="@color/text_secondary"
@@ -66,10 +96,27 @@
             android:id="@+id/tvLastSleep"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="32dp"
+            android:layout_marginTop="16dp"
             android:textSize="14sp"
             android:textColor="@color/text_secondary"
             android:gravity="center" />
+
+        <!-- Histórico 7 dias -->
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:layout_marginBottom="8dp"
+            android:text="Últimos 7 dias"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:textColor="@color/text_primary" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rvHistory"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:nestedScrollingEnabled="false" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/item_sleep_history.xml
+++ b/app/src/main/res/layout/item_sleep_history.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="8dp"
+    app:cardCornerRadius="12dp"
+    app:cardElevation="0dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp"
+        android:gravity="center_vertical"
+        android:background="@color/surface">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/tvDate"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="12sp"
+                android:textColor="@color/text_secondary" />
+
+            <TextView
+                android:id="@+id/tvDuration"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="16sp"
+                android:textStyle="bold"
+                android:textColor="@color/text_primary" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center">
+
+            <TextView
+                android:id="@+id/tvScore"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="24sp"
+                android:textStyle="bold"
+                android:textColor="@color/sleep" />
+
+            <TextView
+                android:id="@+id/tvClassification"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="12sp"
+                android:textColor="@color/text_secondary" />
+
+        </LinearLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnDelete"
+            style="@style/Widget.Material3.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Apagar"
+            android:textColor="@color/error" />
+
+    </LinearLayout>
+
+</androidx.cardview.widget.CardView>


### PR DESCRIPTION
## O que foi feito
Implementação da issue #8 — Score de Qualidade do Sono

## Mudanças
* `SleepDao` atualizado com query `getLastTwo` e `delete`
* `SleepRepository` com cálculo de score, classificação e dicas personalizadas
* `SleepViewModel` atualizado com `_score`, `_classification`, `_tip` e `_history` como `SleepWithScore`
* `SleepWithScore` criado como modelo de dados para o histórico
* `SleepHistoryAdapter` atualizado com botão de apagar
* `item_sleep_history.xml` atualizado com botão de apagar
* `fragment_sleep.xml` atualizado com score, classificação, dica e histórico
* `SleepFragment` atualizado com observação de score, classificação, dica e histórico
* Score mínimo de 60 minutos para ter pontuação
* Query `getLast7Days` corrigida para ordenar por `id DESC`

## Critérios de aceite atendidos
* [x] Score calculado de 0 a 100 após registrar acordar
* [x] Score considera duração, consistência de horário e agitação noturna
* [x] Classificação exibida: Ruim, Regular, Bom ou Excelente
* [x] Dica personalizada exibida com base no score
* [x] Histórico dos últimos 7 dias visível na tela
* [x] Opção de apagar registros do histórico



Closes #8