### PR TITLE
feature(ep-05): add nutrition scanner with ML Kit OCR and meal tracking

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+
+
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_HEALTH" />
@@ -10,6 +15,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
 
 
@@ -70,6 +76,16 @@
         <!-- Sleep -->
         <activity
             android:name=".ui.activity.SleepActivity"
+            android:exported="false" />
+
+        <!-- Scanner -->
+        <activity
+            android:name=".ui.activity.ScannerActivity"
+            android:exported="false" />
+
+        <!-- Nutrition -->
+        <activity
+            android:name=".ui.activity.NutritionActivity"
             android:exported="false" />
 
         <service

--- a/app/src/main/java/com/vitaltrack/app/data/local/dao/MealDao.kt
+++ b/app/src/main/java/com/vitaltrack/app/data/local/dao/MealDao.kt
@@ -1,0 +1,21 @@
+package com.vitaltrack.app.data.local.dao
+
+import androidx.room.*
+import com.vitaltrack.app.data.local.entity.MealEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface MealDao {
+
+    @Insert
+    suspend fun insert(meal: MealEntity)
+
+    @Delete
+    suspend fun delete(meal: MealEntity)
+
+    @Query("SELECT * FROM meal WHERE date = :date ORDER BY time DESC")
+    fun getByDate(date: String): Flow<List<MealEntity>>
+
+    @Query("SELECT SUM(calories) FROM meal WHERE date = :date")
+    fun getTotalCaloriesByDate(date: String): Flow<Int?>
+}

--- a/app/src/main/java/com/vitaltrack/app/data/local/database/VitalTrackDatabase.kt
+++ b/app/src/main/java/com/vitaltrack/app/data/local/database/VitalTrackDatabase.kt
@@ -3,11 +3,13 @@ package com.vitaltrack.app.data.local.database
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import com.vitaltrack.app.data.local.dao.GpsTrackingDao
+import com.vitaltrack.app.data.local.dao.MealDao
 import com.vitaltrack.app.data.local.dao.SleepDao
 import com.vitaltrack.app.data.local.dao.StepCounterDao
 import com.vitaltrack.app.data.local.dao.UserDao
 import com.vitaltrack.app.data.local.dao.WaterIntakeDao
 import com.vitaltrack.app.data.local.entity.GpsTrackingEntity
+import com.vitaltrack.app.data.local.entity.MealEntity
 import com.vitaltrack.app.data.local.entity.SleepEntity
 import com.vitaltrack.app.data.local.entity.StepCounterEntity
 import com.vitaltrack.app.data.local.entity.UserEntity
@@ -19,9 +21,10 @@ import com.vitaltrack.app.data.local.entity.WaterIntakeEntity
         StepCounterEntity::class,
         GpsTrackingEntity::class,
         WaterIntakeEntity::class,
-        SleepEntity::class
+        SleepEntity::class,
+        MealEntity::class
                ],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 
@@ -31,4 +34,5 @@ abstract class VitalTrackDatabase : RoomDatabase() {
     abstract fun gpsTrackingDao(): GpsTrackingDao
     abstract fun waterIntakeDao(): WaterIntakeDao
     abstract fun sleepDao(): SleepDao
+    abstract fun mealDao(): MealDao
 }

--- a/app/src/main/java/com/vitaltrack/app/data/local/entity/MealEntity.kt
+++ b/app/src/main/java/com/vitaltrack/app/data/local/entity/MealEntity.kt
@@ -1,0 +1,18 @@
+package com.vitaltrack.app.data.local.entity
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "meal")
+data class MealEntity(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val description: String,
+    val category: String,
+    val calories: Int,
+    val protein: Float,
+    val carbs: Float,
+    val fat: Float,
+    val date: String,
+    val time: String
+)

--- a/app/src/main/java/com/vitaltrack/app/data/repository/MealRepository.kt
+++ b/app/src/main/java/com/vitaltrack/app/data/repository/MealRepository.kt
@@ -1,0 +1,48 @@
+package com.vitaltrack.app.data.repository
+
+import com.vitaltrack.app.data.local.dao.MealDao
+import com.vitaltrack.app.data.local.entity.MealEntity
+import kotlinx.coroutines.flow.Flow
+import java.text.SimpleDateFormat
+import java.util.*
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class MealRepository @Inject constructor(
+    private val mealDao: MealDao
+) {
+    private fun today(): String =
+        SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(Date())
+
+    private fun now(): String =
+        SimpleDateFormat("HH:mm", Locale.getDefault()).format(Date())
+
+    fun getTodayMeals(): Flow<List<MealEntity>> = mealDao.getByDate(today())
+
+    fun getTodayCalories(): Flow<Int?> = mealDao.getTotalCaloriesByDate(today())
+
+    suspend fun saveMeal(
+        description: String,
+        category: String,
+        calories: Int,
+        protein: Float,
+        carbs: Float,
+        fat: Float
+    ) {
+        mealDao.insert(
+            MealEntity(
+                description = description,
+                category = category,
+                calories = calories,
+                protein = protein,
+                carbs = carbs,
+                fat = fat,
+                date = today(),
+                time = now()
+            )
+        )
+    }
+
+    suspend fun delete(meal: MealEntity) = mealDao.delete(meal)
+}

--- a/app/src/main/java/com/vitaltrack/app/di/DatabaseModule.kt
+++ b/app/src/main/java/com/vitaltrack/app/di/DatabaseModule.kt
@@ -3,6 +3,7 @@ package com.vitaltrack.app.di
 import android.content.Context
 import androidx.room.Room
 import com.vitaltrack.app.data.local.dao.GpsTrackingDao
+import com.vitaltrack.app.data.local.dao.MealDao
 import com.vitaltrack.app.data.local.dao.SleepDao
 import com.vitaltrack.app.data.local.dao.StepCounterDao
 import com.vitaltrack.app.data.local.database.VitalTrackDatabase
@@ -54,5 +55,10 @@ object DatabaseModule {
     @Provides
     fun provideSleepDao(database: VitalTrackDatabase): SleepDao {
         return database.sleepDao()
+    }
+
+    @Provides
+    fun provideMealDao(database: VitalTrackDatabase): MealDao {
+        return database.mealDao()
     }
 }

--- a/app/src/main/java/com/vitaltrack/app/ui/activity/DashboardActivity.kt
+++ b/app/src/main/java/com/vitaltrack/app/ui/activity/DashboardActivity.kt
@@ -48,6 +48,10 @@ class DashboardActivity : AppCompatActivity() {
         binding.cardSleep.setOnClickListener {
             startActivity(Intent(this, SleepActivity::class.java))
         }
+
+        binding.cardNutrition.setOnClickListener {
+            startActivity(Intent(this, NutritionActivity::class.java))
+        }
     }
 
 

--- a/app/src/main/java/com/vitaltrack/app/ui/activity/NutritionActivity.kt
+++ b/app/src/main/java/com/vitaltrack/app/ui/activity/NutritionActivity.kt
@@ -1,0 +1,23 @@
+package com.vitaltrack.app.ui.activity
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.vitaltrack.app.databinding.ActivityNutritionBinding
+import com.vitaltrack.app.ui.nutrition.NutritionFragment
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class NutritionActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityNutritionBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityNutritionBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        supportFragmentManager.beginTransaction()
+            .replace(binding.fragmentContainer.id, NutritionFragment())
+            .commit()
+    }
+}

--- a/app/src/main/java/com/vitaltrack/app/ui/activity/ScannerActivity.kt
+++ b/app/src/main/java/com/vitaltrack/app/ui/activity/ScannerActivity.kt
@@ -1,0 +1,121 @@
+package com.vitaltrack.app.ui.activity
+
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.util.Log
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.camera.core.*
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.core.content.ContextCompat
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.text.TextRecognition
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions
+import com.vitaltrack.app.databinding.ActivityScannerBinding
+import dagger.hilt.android.AndroidEntryPoint
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+@AndroidEntryPoint
+class ScannerActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityScannerBinding
+    private lateinit var cameraExecutor: ExecutorService
+    private var imageAnalysis: ImageAnalysis? = null
+    private var lastScannedText = ""
+
+    private val permissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        if (granted) startCamera()
+        else finish()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityScannerBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        cameraExecutor = Executors.newSingleThreadExecutor()
+
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA)
+            == PackageManager.PERMISSION_GRANTED
+        ) {
+            startCamera()
+        } else {
+            permissionLauncher.launch(Manifest.permission.CAMERA)
+        }
+
+        binding.btnCapture.setOnClickListener {
+            if (lastScannedText.isNotEmpty()) {
+                val result = Intent()
+                result.putExtra("scanned_text", lastScannedText)
+                setResult(RESULT_OK, result)
+                finish()
+            }
+        }
+
+        binding.btnCancel.setOnClickListener { finish() }
+    }
+
+    private fun startCamera() {
+        val cameraProviderFuture = ProcessCameraProvider.getInstance(this)
+        cameraProviderFuture.addListener({
+            val cameraProvider = cameraProviderFuture.get()
+
+            val preview = Preview.Builder().build().also {
+                it.setSurfaceProvider(binding.previewView.surfaceProvider)
+            }
+
+            val recognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
+
+            imageAnalysis = ImageAnalysis.Builder()
+                .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+                .build()
+                .also { analysis ->
+                    analysis.setAnalyzer(cameraExecutor) { imageProxy ->
+                        val mediaImage = imageProxy.image
+                        if (mediaImage != null) {
+                            val image = InputImage.fromMediaImage(
+                                mediaImage,
+                                imageProxy.imageInfo.rotationDegrees
+                            )
+                            recognizer.process(image)
+                                .addOnSuccessListener { result ->
+                                    val text = result.text
+                                    if (text.isNotEmpty()) {
+                                        lastScannedText = text
+                                        runOnUiThread {
+                                            binding.tvScannedText.text = "Texto detectado — toque em Capturar"
+                                        }
+                                    }
+                                }
+                                .addOnFailureListener { Log.e("Scanner", it.message ?: "") }
+                                .addOnCompleteListener { imageProxy.close() }
+                        } else {
+                            imageProxy.close()
+                        }
+                    }
+                }
+
+            try {
+                cameraProvider.unbindAll()
+                cameraProvider.bindToLifecycle(
+                    this,
+                    CameraSelector.DEFAULT_BACK_CAMERA,
+                    preview,
+                    imageAnalysis
+                )
+            } catch (e: Exception) {
+                Log.e("Scanner", e.message ?: "")
+            }
+        }, ContextCompat.getMainExecutor(this))
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        cameraExecutor.shutdown()
+    }
+}

--- a/app/src/main/java/com/vitaltrack/app/ui/nutrition/MealAdapter.kt
+++ b/app/src/main/java/com/vitaltrack/app/ui/nutrition/MealAdapter.kt
@@ -1,0 +1,43 @@
+package com.vitaltrack.app.ui.nutrition
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.vitaltrack.app.data.local.entity.MealEntity
+import com.vitaltrack.app.databinding.ItemMealBinding
+
+class MealAdapter(
+    private val onDelete: (MealEntity) -> Unit
+) : ListAdapter<MealEntity, MealAdapter.ViewHolder>(DiffCallback()) {
+
+    inner class ViewHolder(private val binding: ItemMealBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: MealEntity) {
+            binding.tvDescription.text = item.description
+            binding.tvCategory.text = item.category
+            binding.tvCalories.text = "${item.calories} kcal"
+            binding.tvTime.text = item.time
+            binding.tvMacros.text = "P: ${item.protein}g | C: ${item.carbs}g | G: ${item.fat}g"
+            binding.btnDelete.setOnClickListener { onDelete(item) }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val binding = ItemMealBinding.inflate(
+            LayoutInflater.from(parent.context), parent, false
+        )
+        return ViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class DiffCallback : DiffUtil.ItemCallback<MealEntity>() {
+        override fun areItemsTheSame(a: MealEntity, b: MealEntity) = a.id == b.id
+        override fun areContentsTheSame(a: MealEntity, b: MealEntity) = a == b
+    }
+}

--- a/app/src/main/java/com/vitaltrack/app/ui/nutrition/NutritionFragment.kt
+++ b/app/src/main/java/com/vitaltrack/app/ui/nutrition/NutritionFragment.kt
@@ -1,0 +1,154 @@
+package com.vitaltrack.app.ui.nutrition
+
+import android.app.Activity
+import android.app.AlertDialog
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.EditText
+import android.widget.Spinner
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.vitaltrack.app.databinding.FragmentNutritionBinding
+import com.vitaltrack.app.ui.activity.ScannerActivity
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class NutritionFragment : Fragment() {
+
+    private var _binding: FragmentNutritionBinding? = null
+    private val binding get() = _binding!!
+    private val viewModel: NutritionViewModel by viewModels()
+    private val adapter = MealAdapter { viewModel.deleteMeal(it) }
+
+    private val scannerLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        if (result.resultCode == Activity.RESULT_OK) {
+            val text = result.data?.getStringExtra("scanned_text") ?: ""
+            val nutrition = viewModel.parseScannedText(text)
+            showConfirmDialog(nutrition)
+        } else {
+            // fallback para manual
+            showManualDialog()
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentNutritionBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.rvMeals.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = this@NutritionFragment.adapter
+        }
+
+        binding.btnScan.setOnClickListener {
+            scannerLauncher.launch(
+                Intent(requireContext(), ScannerActivity::class.java)
+            )
+        }
+
+        binding.btnManual.setOnClickListener {
+            showManualDialog()
+        }
+
+        observeViewModel()
+    }
+
+    private fun observeViewModel() {
+        lifecycleScope.launch {
+            launch {
+                viewModel.meals.collect { adapter.submitList(it) }
+            }
+            launch {
+                viewModel.totalCalories.collect { total ->
+                    binding.tvTotalCalories.text = "$total kcal"
+                }
+            }
+        }
+    }
+
+    private fun showConfirmDialog(nutrition: ScannedNutrition) {
+        val layout = android.widget.LinearLayout(requireContext())
+        layout.orientation = android.widget.LinearLayout.VERTICAL
+        layout.setPadding(48, 24, 48, 0)
+
+        val etDescription = EditText(requireContext()).apply { hint = "Descrição" }
+        val etCalories = EditText(requireContext()).apply {
+            hint = "Calorias"
+            inputType = android.text.InputType.TYPE_CLASS_NUMBER
+            setText(if (nutrition.calories > 0) nutrition.calories.toString() else "")
+        }
+        val etProtein = EditText(requireContext()).apply {
+            hint = "Proteínas (g)"
+            inputType = android.text.InputType.TYPE_NUMBER_FLAG_DECIMAL
+            setText(if (nutrition.protein > 0) nutrition.protein.toString() else "")
+        }
+        val etCarbs = EditText(requireContext()).apply {
+            hint = "Carboidratos (g)"
+            inputType = android.text.InputType.TYPE_NUMBER_FLAG_DECIMAL
+            setText(if (nutrition.carbs > 0) nutrition.carbs.toString() else "")
+        }
+        val etFat = EditText(requireContext()).apply {
+            hint = "Gorduras (g)"
+            inputType = android.text.InputType.TYPE_NUMBER_FLAG_DECIMAL
+            setText(if (nutrition.fat > 0) nutrition.fat.toString() else "")
+        }
+
+        val spinner = Spinner(requireContext())
+        val categories = listOf("Café da manhã", "Almoço", "Jantar", "Lanche")
+        spinner.adapter = ArrayAdapter(
+            requireContext(),
+            android.R.layout.simple_spinner_dropdown_item,
+            categories
+        )
+
+        layout.addView(etDescription)
+        layout.addView(spinner)
+        layout.addView(etCalories)
+        layout.addView(etProtein)
+        layout.addView(etCarbs)
+        layout.addView(etFat)
+
+        AlertDialog.Builder(requireContext())
+            .setTitle("Confirmar dados nutricionais")
+            .setView(layout)
+            .setPositiveButton("Salvar") { _, _ ->
+                viewModel.saveMeal(
+                    description = etDescription.text.toString().ifEmpty { "Refeição" },
+                    category = spinner.selectedItem.toString(),
+                    calories = etCalories.text.toString().toIntOrNull() ?: 0,
+                    protein = etProtein.text.toString().toFloatOrNull() ?: 0f,
+                    carbs = etCarbs.text.toString().toFloatOrNull() ?: 0f,
+                    fat = etFat.text.toString().toFloatOrNull() ?: 0f
+                )
+            }
+            .setNegativeButton("Cancelar", null)
+            .show()
+    }
+
+    private fun showManualDialog() {
+        showConfirmDialog(ScannedNutrition(0, 0f, 0f, 0f))
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/vitaltrack/app/ui/nutrition/NutritionViewModel.kt
+++ b/app/src/main/java/com/vitaltrack/app/ui/nutrition/NutritionViewModel.kt
@@ -1,0 +1,168 @@
+package com.vitaltrack.app.ui.nutrition
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.vitaltrack.app.data.local.entity.MealEntity
+import com.vitaltrack.app.data.repository.MealRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class NutritionViewModel @Inject constructor(
+    private val mealRepository: MealRepository
+) : ViewModel() {
+
+    private val _meals = MutableStateFlow<List<MealEntity>>(emptyList())
+    val meals: StateFlow<List<MealEntity>> = _meals.asStateFlow()
+
+    private val _totalCalories = MutableStateFlow(0)
+    val totalCalories: StateFlow<Int> = _totalCalories.asStateFlow()
+
+    init {
+        loadData()
+    }
+
+    private fun loadData() {
+        viewModelScope.launch {
+            launch {
+                mealRepository.getTodayMeals().collect { _meals.value = it }
+            }
+            launch {
+                mealRepository.getTodayCalories().collect {
+                    _totalCalories.value = it ?: 0
+                }
+            }
+        }
+    }
+
+    fun saveMeal(
+        description: String,
+        category: String,
+        calories: Int,
+        protein: Float,
+        carbs: Float,
+        fat: Float
+    ) {
+        viewModelScope.launch {
+            mealRepository.saveMeal(description, category, calories, protein, carbs, fat)
+        }
+    }
+
+    fun deleteMeal(meal: MealEntity) {
+        viewModelScope.launch {
+            mealRepository.delete(meal)
+        }
+    }
+
+    fun parseScannedText(text: String): ScannedNutrition {
+        var calories = 0
+        var protein = 0f
+        var carbs = 0f
+        var fat = 0f
+
+        val lines = text.lines()
+
+        for (line in lines) {
+            val lower = line.lowercase().trim()
+
+
+            val cleaned = lower
+                .replace(",", ".")
+                .replace("kcal", " kcal")
+                .replace("kj", " kj")
+                .replace("O", "0")
+                .replace("o", "0")
+                .replace("l", "1")
+                .replace("I", "1")
+                // corrige "109" → "10" quando provavelmente era "10g"
+                .replace(Regex("(\\d)9(?=\\s|$)"), "$1")
+
+
+            val matches = Regex("(\\d+(?:\\.\\d+)?)\\s*(kcal|kj|g|mg)?")
+                .findAll(cleaned)
+                .mapNotNull { match ->
+                    val value = match.groupValues[1].toFloatOrNull()
+                    val unit = match.groupValues[2]
+
+                    if (value != null) Pair(value, unit) else null
+                }
+                .toList()
+
+            if (matches.isEmpty()) continue
+
+
+            if (
+                lower.contains("valor energ") ||
+                lower.contains("energia") ||
+                lower.contains("kcal")
+            ) {
+                val kcal = matches.firstOrNull {
+                    it.second == "kcal" && it.first in 10f..2000f
+                }?.first
+
+                val fallback = matches.firstOrNull {
+                    it.first in 10f..2000f
+                }?.first
+
+                calories = (kcal ?: fallback ?: calories.toFloat()).toInt()
+            }
+
+
+            if (lower.contains("prote")) {
+                val value = matches.firstOrNull {
+                    (it.second == "g" || it.second.isEmpty()) &&
+                            it.first in 0.1f..200f
+                }?.first
+
+                if (value != null) protein = value
+            }
+
+
+            if (
+                (lower.contains("carboidrato") || lower.contains("carb")) &&
+                !lower.contains("açucar") &&
+                !lower.contains("adicion")
+            ) {
+                val value = matches.firstOrNull {
+                    (it.second == "g" || it.second.isEmpty()) &&
+                            it.first in 0.1f..500f
+                }?.first
+
+                if (value != null && carbs == 0f) carbs = value
+            }
+
+
+            if (
+                (lower.contains("gordura") || lower.contains("lipid")) &&
+                !lower.contains("satur") &&
+                !lower.contains("trans") &&
+                !lower.contains("mono") &&
+                !lower.contains("poli")
+            ) {
+                val value = matches.firstOrNull {
+                    (it.second == "g" || it.second.isEmpty()) &&
+                            it.first in 0.1f..200f
+                }?.first
+
+                if (value != null && fat == 0f) fat = value
+            }
+        }
+
+        if (calories == 0 && (protein > 0 || carbs > 0 || fat > 0)) {
+            calories = ((protein * 4) + (carbs * 4) + (fat * 9)).toInt()
+        }
+
+        return ScannedNutrition(calories, protein, carbs, fat)
+    }
+}
+
+data class ScannedNutrition(
+    val calories: Int,
+    val protein: Float,
+    val carbs: Float,
+    val fat: Float
+)

--- a/app/src/main/res/layout/activity_dashboard.xml
+++ b/app/src/main/res/layout/activity_dashboard.xml
@@ -197,6 +197,7 @@
 
             <!-- Nutrição -->
             <androidx.cardview.widget.CardView
+                android:id="@+id/cardNutrition"
                 android:layout_width="0dp"
                 android:layout_height="100dp"
                 android:layout_columnWeight="1"

--- a/app/src/main/res/layout/activity_nutrition.xml
+++ b/app/src/main/res/layout/activity_nutrition.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <FrameLayout
+        android:id="@+id/fragmentContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/activity_scanner.xml
+++ b/app/src/main/res/layout/activity_scanner.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.camera.view.PreviewView
+        android:id="@+id/previewView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/tvScannedText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp"
+        android:background="#CC000000"
+        android:textColor="#FFFFFF"
+        android:textSize="14sp"
+        android:text="Aponte a câmera para o rótulo"
+        android:gravity="center"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="16dp"
+        android:gravity="center"
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnCancel"
+            style="@style/Widget.Material3.Button.OutlinedButton"
+            android:layout_width="0dp"
+            android:layout_height="56dp"
+            android:layout_weight="1"
+            android:layout_marginEnd="8dp"
+            android:text="Cancelar" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnCapture"
+            android:layout_width="0dp"
+            android:layout_height="56dp"
+            android:layout_weight="1"
+            android:text="Capturar" />
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_nutrition.xml
+++ b/app/src/main/res/layout/fragment_nutrition.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/background">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Nutrição"
+            android:textSize="24sp"
+            android:textStyle="bold"
+            android:textColor="@color/text_primary" />
+
+        <TextView
+            android:id="@+id/tvTotalCalories"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="0 kcal"
+            android:textSize="48sp"
+            android:textStyle="bold"
+            android:textColor="@color/nutrition" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="total hoje"
+            android:textSize="14sp"
+            android:textColor="@color/text_secondary" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnScan"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:layout_marginTop="24dp"
+            android:text="Escanear rótulo" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnManual"
+            style="@style/Widget.Material3.Button.OutlinedButton"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:layout_marginTop="8dp"
+            android:text="Registrar manualmente" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:layout_marginBottom="8dp"
+            android:text="Refeições de hoje"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:textColor="@color/text_primary" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rvMeals"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:nestedScrollingEnabled="false" />
+
+    </LinearLayout>
+
+</ScrollView>

--- a/app/src/main/res/layout/item_meal.xml
+++ b/app/src/main/res/layout/item_meal.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="8dp"
+    app:cardCornerRadius="12dp"
+    app:cardElevation="0dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp"
+        android:background="@color/surface">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical">
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/tvDescription"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="16sp"
+                    android:textStyle="bold"
+                    android:textColor="@color/text_primary" />
+
+                <TextView
+                    android:id="@+id/tvCategory"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textSize="12sp"
+                    android:textColor="@color/text_secondary" />
+
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/tvCalories"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="16sp"
+                android:textStyle="bold"
+                android:textColor="@color/nutrition"
+                android:layout_marginEnd="8dp" />
+
+            <TextView
+                android:id="@+id/tvTime"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="12sp"
+                android:textColor="@color/text_secondary" />
+
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/tvMacros"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textSize="12sp"
+            android:textColor="@color/text_secondary" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnDelete"
+            style="@style/Widget.Material3.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Remover"
+            android:textColor="@color/error" />
+
+    </LinearLayout>
+
+</androidx.cardview.widget.CardView>


### PR DESCRIPTION
## O que foi feito
Implementação da issue #11 — Scanner de Rótulo Nutricional

## Mudanças
* `MealEntity` criada para persistir refeições no Room DB
* `MealDao` com queries de inserção, deleção e total de calorias
* `VitalTrackDatabase` atualizado para versão 6
* `DatabaseModule` atualizado com `MealDao`
* `MealRepository` com lógica de data e hora automática
* `NutritionViewModel` com parser de OCR calibrado para rótulos brasileiros
* `MealAdapter` com ListAdapter e opção de remover
* `NutritionFragment` com scanner e registro manual
* `ScannerActivity` com CameraX e ML Kit OCR em tempo real
* `fragment_nutrition.xml` com total de calorias e lista de refeições
* `item_meal.xml` com card de refeição e macros
* `NutritionActivity` criada para hospedar o fragment
* `DashboardActivity` atualizado com clique no card de Nutrição
* Parser OCR corrigido para padrão ANVISA brasileiro

## Critérios de aceite atendidos
* [x] Câmera abre em tela cheia ao tocar em "Escanear rótulo"
* [x] ML Kit OCR extrai texto do rótulo em tempo real
* [x] App identifica calorias, proteínas, carboidratos e gorduras
* [x] Dados extraídos exibidos para confirmação antes de salvar
* [x] Usuário pode editar campos antes de confirmar
* [x] Registro salvo no Room DB com horário e categoria da refeição
* [x] Fallback para entrada manual se OCR falhar


Closes #11