### PR TITLE
feature(ep-05): add meal edit functionality with update dialog

### DIFF
--- a/app/src/main/java/com/vitaltrack/app/data/local/dao/MealDao.kt
+++ b/app/src/main/java/com/vitaltrack/app/data/local/dao/MealDao.kt
@@ -10,8 +10,12 @@ interface MealDao {
     @Insert
     suspend fun insert(meal: MealEntity)
 
+    @Update
+    suspend fun update(meal: MealEntity)
+
     @Delete
     suspend fun delete(meal: MealEntity)
+
 
     @Query("SELECT * FROM meal WHERE date = :date ORDER BY time DESC")
     fun getByDate(date: String): Flow<List<MealEntity>>

--- a/app/src/main/java/com/vitaltrack/app/data/repository/MealRepository.kt
+++ b/app/src/main/java/com/vitaltrack/app/data/repository/MealRepository.kt
@@ -22,6 +22,8 @@ class MealRepository @Inject constructor(
 
     fun getTodayCalories(): Flow<Int?> = mealDao.getTotalCaloriesByDate(today())
 
+    suspend fun update(meal: MealEntity) = mealDao.update(meal)
+
     suspend fun saveMeal(
         description: String,
         category: String,

--- a/app/src/main/java/com/vitaltrack/app/ui/nutrition/MealAdapter.kt
+++ b/app/src/main/java/com/vitaltrack/app/ui/nutrition/MealAdapter.kt
@@ -9,7 +9,8 @@ import com.vitaltrack.app.data.local.entity.MealEntity
 import com.vitaltrack.app.databinding.ItemMealBinding
 
 class MealAdapter(
-    private val onDelete: (MealEntity) -> Unit
+    private val onDelete: (MealEntity) -> Unit,
+    private val onEdit: (MealEntity) -> Unit
 ) : ListAdapter<MealEntity, MealAdapter.ViewHolder>(DiffCallback()) {
 
     inner class ViewHolder(private val binding: ItemMealBinding) :
@@ -22,6 +23,7 @@ class MealAdapter(
             binding.tvTime.text = item.time
             binding.tvMacros.text = "P: ${item.protein}g | C: ${item.carbs}g | G: ${item.fat}g"
             binding.btnDelete.setOnClickListener { onDelete(item) }
+            binding.btnEdit.setOnClickListener { onEdit(item) }
         }
     }
 

--- a/app/src/main/java/com/vitaltrack/app/ui/nutrition/NutritionFragment.kt
+++ b/app/src/main/java/com/vitaltrack/app/ui/nutrition/NutritionFragment.kt
@@ -15,6 +15,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.vitaltrack.app.data.local.entity.MealEntity
 import com.vitaltrack.app.databinding.FragmentNutritionBinding
 import com.vitaltrack.app.ui.activity.ScannerActivity
 import dagger.hilt.android.AndroidEntryPoint
@@ -26,7 +27,10 @@ class NutritionFragment : Fragment() {
     private var _binding: FragmentNutritionBinding? = null
     private val binding get() = _binding!!
     private val viewModel: NutritionViewModel by viewModels()
-    private val adapter = MealAdapter { viewModel.deleteMeal(it) }
+    private val adapter = MealAdapter(
+        onDelete = { viewModel.deleteMeal(it) },
+        onEdit = { showEditDialog(it) }
+    )
 
     private val scannerLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
@@ -145,6 +149,70 @@ class NutritionFragment : Fragment() {
 
     private fun showManualDialog() {
         showConfirmDialog(ScannedNutrition(0, 0f, 0f, 0f))
+    }
+
+    private fun showEditDialog(meal: MealEntity) {
+        val layout = android.widget.LinearLayout(requireContext())
+        layout.orientation = android.widget.LinearLayout.VERTICAL
+        layout.setPadding(48, 24, 48, 0)
+
+        val etDescription = android.widget.EditText(requireContext()).apply {
+            hint = "Descrição"
+            setText(meal.description)
+        }
+        val etCalories = android.widget.EditText(requireContext()).apply {
+            hint = "Calorias"
+            inputType = android.text.InputType.TYPE_CLASS_NUMBER
+            setText(meal.calories.toString())
+        }
+        val etProtein = android.widget.EditText(requireContext()).apply {
+            hint = "Proteínas (g)"
+            inputType = android.text.InputType.TYPE_NUMBER_FLAG_DECIMAL
+            setText(meal.protein.toString())
+        }
+        val etCarbs = android.widget.EditText(requireContext()).apply {
+            hint = "Carboidratos (g)"
+            inputType = android.text.InputType.TYPE_NUMBER_FLAG_DECIMAL
+            setText(meal.carbs.toString())
+        }
+        val etFat = android.widget.EditText(requireContext()).apply {
+            hint = "Gorduras (g)"
+            inputType = android.text.InputType.TYPE_NUMBER_FLAG_DECIMAL
+            setText(meal.fat.toString())
+        }
+
+        val spinner = android.widget.Spinner(requireContext())
+        val categories = listOf("Café da manhã", "Almoço", "Jantar", "Lanche")
+        spinner.adapter = android.widget.ArrayAdapter(
+            requireContext(),
+            android.R.layout.simple_spinner_dropdown_item,
+            categories
+        )
+        spinner.setSelection(categories.indexOf(meal.category).coerceAtLeast(0))
+
+        layout.addView(etDescription)
+        layout.addView(spinner)
+        layout.addView(etCalories)
+        layout.addView(etProtein)
+        layout.addView(etCarbs)
+        layout.addView(etFat)
+
+        android.app.AlertDialog.Builder(requireContext())
+            .setTitle("Editar refeição")
+            .setView(layout)
+            .setPositiveButton("Salvar") { _, _ ->
+                val updated = meal.copy(
+                    description = etDescription.text.toString().ifEmpty { meal.description },
+                    category = spinner.selectedItem.toString(),
+                    calories = etCalories.text.toString().toIntOrNull() ?: meal.calories,
+                    protein = etProtein.text.toString().toFloatOrNull() ?: meal.protein,
+                    carbs = etCarbs.text.toString().toFloatOrNull() ?: meal.carbs,
+                    fat = etFat.text.toString().toFloatOrNull() ?: meal.fat
+                )
+                viewModel.updateMeal(updated)
+            }
+            .setNegativeButton("Cancelar", null)
+            .show()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/vitaltrack/app/ui/nutrition/NutritionViewModel.kt
+++ b/app/src/main/java/com/vitaltrack/app/ui/nutrition/NutritionViewModel.kt
@@ -52,6 +52,12 @@ class NutritionViewModel @Inject constructor(
         }
     }
 
+    fun updateMeal(meal: MealEntity) {
+        viewModelScope.launch {
+            mealRepository.update(meal)
+        }
+    }
+
     fun deleteMeal(meal: MealEntity) {
         viewModelScope.launch {
             mealRepository.delete(meal)

--- a/app/src/main/res/layout/item_meal.xml
+++ b/app/src/main/res/layout/item_meal.xml
@@ -71,6 +71,14 @@
             android:textColor="@color/text_secondary" />
 
         <com.google.android.material.button.MaterialButton
+            android:id="@+id/btnEdit"
+            style="@style/Widget.Material3.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Editar"
+            android:textColor="@color/primary" />
+
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/btnDelete"
             style="@style/Widget.Material3.Button.TextButton"
             android:layout_width="wrap_content"


### PR DESCRIPTION
## O que foi feito
Atualização da issue #12 — Adicionado edição de refeições

## Mudanças
* `MealDao` atualizado com `@Update`
* `MealRepository` atualizado com função `update`
* `NutritionViewModel` atualizado com função `updateMeal`
* `MealAdapter` atualizado com callback `onEdit`
* `item_meal.xml` atualizado com botão "Editar"
* `NutritionFragment` atualizado com dialog de edição completo

## Critérios de aceite atendidos
* [x] Formulário com campos: descrição, categoria e calorias
* [x] Categorias disponíveis: Café da manhã, Almoço, Jantar e Lanche
* [x] Horário preenchido automaticamente com timestamp atual
* [x] Total de calorias do dia atualizado após cada registro
* [x] Possibilidade de editar registros do dia
* [x] Possibilidade de excluir registros do dia
* [x] Registro salvo no Room DB


Closes #12